### PR TITLE
Fix handling of SMs

### DIFF
--- a/nvidia_variant_provider/plugin.py
+++ b/nvidia_variant_provider/plugin.py
@@ -272,7 +272,7 @@ class NvidiaVariantPlugin:
         ]:
             return variant_property.value in self.generate_all_umd_values()
 
-        if variant_property.feature == NvidiaVariantFeatureKey.SM.value:
+        if variant_property.feature == NvidiaVariantFeatureKey.SM:
             return variant_property.value in self.generate_all_sm_values()
 
         warnings.warn(


### PR DESCRIPTION
Fix error
```
  File "/home/phcho/.conda/envs/wheelnext/lib/python3.13/site-packages/nvidia_variant_provider/plugin.py", line 275, in validate_property
    if variant_property.feature == NvidiaVariantFeatureKey.SM.value:
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'value'
```